### PR TITLE
Some Image instances don't have a ._getexif() method

### DIFF
--- a/img_rotate.py
+++ b/img_rotate.py
@@ -34,7 +34,7 @@ def fix_orientation(img, save_over=False):
         raise ValueError("You can't use `save_over` when passing an Image instance.  Use a file path instead.")
     try:
         orientation = img._getexif()[EXIF_ORIENTATION_TAG]
-    except TypeError:
+    except (TypeError, AttributeError):
         raise ValueError("Image file has no EXIF data.")
     if orientation in [3,6,8]:
         degrees = ORIENTATIONS[orientation][1]


### PR DESCRIPTION
Treat both TypeError and AttributeError the same when trying to access `Image._getexif`, namely as the image lacking EXIF data.
